### PR TITLE
Improve editorconfig

### DIFF
--- a/config/.editorconfig
+++ b/config/.editorconfig
@@ -16,12 +16,12 @@ indent_size = 4
 trim_trailing_whitespace = false
 max_line_length = 80
 
-[*.{css,less,sass,scss,js,ts,mjs}]
+[*.{html,css,less,sass,scss}]
 indent_size = 4
 max_line_length = 80
 
-[*.{html,vue,jsx,tsx}]
-indent_size = 4
+[*.{js,ts,vue,jsx,tsx}]
+indent_size = 2
 max_line_length = 80
 
 [*.{xml,phtml,php}]


### PR DESCRIPTION
I'd like to not use 4 indents in a js-based file since it can clutter your vision a lot compared to other languages. Therefore I'd like to suggest a two-space based indenting.